### PR TITLE
Update @backstage/plugin-catalog-backend-module-gitlab in 1.27.*

### DIFF
--- a/v1/releases/1.27.0/manifest.json
+++ b/v1/releases/1.27.0/manifest.json
@@ -311,7 +311,7 @@
     },
     {
       "name": "@backstage/plugin-catalog-backend-module-gitlab",
-      "version": "0.3.15"
+      "version": "0.3.16"
     },
     {
       "name": "@backstage/plugin-catalog-backend-module-gitlab-org",

--- a/v1/releases/1.27.1/manifest.json
+++ b/v1/releases/1.27.1/manifest.json
@@ -311,7 +311,7 @@
     },
     {
       "name": "@backstage/plugin-catalog-backend-module-gitlab",
-      "version": "0.3.15"
+      "version": "0.3.16"
     },
     {
       "name": "@backstage/plugin-catalog-backend-module-gitlab-org",


### PR DESCRIPTION
🧹, see https://github.com/backstage/backstage/pull/24774